### PR TITLE
Change the visibility of some private fields to public to be accessed…

### DIFF
--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -49,7 +49,7 @@ pub trait Chip<F: Field>: Sized {
 
 /// Index of a region in a layouter
 #[derive(Clone, Copy, Debug)]
-///Analyzer
+/// Visibility changed for analyzer
 pub struct RegionIndex(pub usize);
 
 impl From<usize> for RegionIndex {
@@ -88,13 +88,13 @@ impl std::ops::Deref for RegionStart {
 #[derive(Clone, Copy, Debug)]
 pub struct Cell {
     /// Identifies the region in which this cell resides.
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub region_index: RegionIndex,
     /// The relative offset of this cell within its region.
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub row_offset: usize,
     /// The column of this cell.
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub column: Column<Any>,
 }
 

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -49,7 +49,8 @@ pub trait Chip<F: Field>: Sized {
 
 /// Index of a region in a layouter
 #[derive(Clone, Copy, Debug)]
-pub struct RegionIndex(usize);
+///Analyzer
+pub struct RegionIndex(pub usize);
 
 impl From<usize> for RegionIndex {
     fn from(idx: usize) -> RegionIndex {
@@ -87,11 +88,14 @@ impl std::ops::Deref for RegionStart {
 #[derive(Clone, Copy, Debug)]
 pub struct Cell {
     /// Identifies the region in which this cell resides.
-    region_index: RegionIndex,
+    ///Analyzer
+    pub region_index: RegionIndex,
     /// The relative offset of this cell within its region.
-    row_offset: usize,
+    ///Analyzer
+    pub row_offset: usize,
     /// The column of this cell.
-    column: Column<Any>,
+    ///Analyzer
+    pub column: Column<Any>,
 }
 
 /// An assigned cell.

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -300,7 +300,7 @@ pub struct MockProver<F: Field> {
     current_region: Option<Region>,
 
     // The fixed cells in the circuit, arranged as [column][row].
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub fixed: Vec<Vec<CellValue<F>>>,
     // The advice cells in the circuit, arranged as [column][row].
     advice: Vec<Vec<CellValue<F>>>,

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -300,7 +300,8 @@ pub struct MockProver<F: Field> {
     current_region: Option<Region>,
 
     // The fixed cells in the circuit, arranged as [column][row].
-    fixed: Vec<Vec<CellValue<F>>>,
+    ///Analyzer
+    pub fixed: Vec<Vec<CellValue<F>>>,
     // The advice cells in the circuit, arranged as [column][row].
     advice: Vec<Vec<CellValue<F>>>,
     // The instance cells in the circuit, arranged as [column][row].

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -29,9 +29,9 @@ pub trait ColumnType:
 /// A column with an index and type
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Column<C: ColumnType> {
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub index: usize,
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub column_type: C,
 }
 
@@ -156,7 +156,7 @@ impl SealedPhase for super::ThirdPhase {
 /// An advice column
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Advice {
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub phase: sealed::Phase,
 }
 
@@ -455,7 +455,7 @@ impl TryFrom<Column<Any>> for Column<Instance> {
 /// }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-///Analyzer
+/// Visibility changed for analyzer
 pub struct Selector(pub usize, bool);
 
 impl Selector {
@@ -482,10 +482,10 @@ pub struct FixedQuery {
     /// Query index
     pub(crate) index: Option<usize>,
     /// Column index
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub column_index: usize,
     /// Rotation of this query
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub rotation: Rotation,
 }
 
@@ -505,13 +505,13 @@ impl FixedQuery {
 #[derive(Copy, Clone, Debug)]
 pub struct AdviceQuery {
     /// Query index
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub index: Option<usize>,
     /// Column index
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub column_index: usize,
     /// Rotation of this query
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub rotation: Rotation,
     /// Phase of this advice column
     pub(crate) phase: sealed::Phase,
@@ -1499,7 +1499,7 @@ impl<F: Field, C: Into<Constraint<F>>, Iter: IntoIterator<Item = C>> IntoIterato
 pub struct Gate<F: Field> {
     name: String,
     constraint_names: Vec<String>,
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub polys: Vec<Expression<F>>,
     /// We track queried selectors separately from other cells, so that we can use them to
     /// trigger debug checks on gates.
@@ -1508,7 +1508,7 @@ pub struct Gate<F: Field> {
 }
 
 impl<F: Field> Gate<F> {
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
@@ -1551,9 +1551,9 @@ pub struct ConstraintSystem<F: Field> {
     /// tooling right now.
     pub(crate) selector_map: Vec<Column<Fixed>>,
 
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub gates: Vec<Gate<F>>,
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub advice_queries: Vec<(Column<Advice>, Rotation)>,
     // Contains an integer for each advice column
     // identifying how many distinct queries it has
@@ -1567,7 +1567,7 @@ pub struct ConstraintSystem<F: Field> {
 
     // Vector of lookup arguments, where each corresponds to a sequence of
     // input expressions and a sequence of table expressions involved in the lookup.
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub lookups: Vec<lookup::Argument<F>>,
 
     // List of indexes of Fixed columns which are associated to a circuit-general Column tied to their annotation.

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -29,8 +29,10 @@ pub trait ColumnType:
 /// A column with an index and type
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Column<C: ColumnType> {
-    index: usize,
-    column_type: C,
+    ///Analyzer
+    pub index: usize,
+    ///Analyzer
+    pub column_type: C,
 }
 
 impl<C: ColumnType> Column<C> {
@@ -154,7 +156,8 @@ impl SealedPhase for super::ThirdPhase {
 /// An advice column
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Advice {
-    pub(crate) phase: sealed::Phase,
+    ///Analyzer
+    pub phase: sealed::Phase,
 }
 
 impl Default for Advice {
@@ -452,7 +455,8 @@ impl TryFrom<Column<Any>> for Column<Instance> {
 /// }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Selector(pub(crate) usize, bool);
+///Analyzer
+pub struct Selector(pub usize, bool);
 
 impl Selector {
     /// Enable this selector at the given offset within the given region.
@@ -478,9 +482,11 @@ pub struct FixedQuery {
     /// Query index
     pub(crate) index: Option<usize>,
     /// Column index
-    pub(crate) column_index: usize,
+    ///Analyzer
+    pub column_index: usize,
     /// Rotation of this query
-    pub(crate) rotation: Rotation,
+    ///Analyzer
+    pub rotation: Rotation,
 }
 
 impl FixedQuery {
@@ -499,11 +505,14 @@ impl FixedQuery {
 #[derive(Copy, Clone, Debug)]
 pub struct AdviceQuery {
     /// Query index
-    pub(crate) index: Option<usize>,
+    ///Analyzer
+    pub index: Option<usize>,
     /// Column index
-    pub(crate) column_index: usize,
+    ///Analyzer
+    pub column_index: usize,
     /// Rotation of this query
-    pub(crate) rotation: Rotation,
+    ///Analyzer
+    pub rotation: Rotation,
     /// Phase of this advice column
     pub(crate) phase: sealed::Phase,
 }
@@ -1490,7 +1499,8 @@ impl<F: Field, C: Into<Constraint<F>>, Iter: IntoIterator<Item = C>> IntoIterato
 pub struct Gate<F: Field> {
     name: String,
     constraint_names: Vec<String>,
-    polys: Vec<Expression<F>>,
+    ///Analyzer
+    pub polys: Vec<Expression<F>>,
     /// We track queried selectors separately from other cells, so that we can use them to
     /// trigger debug checks on gates.
     queried_selectors: Vec<Selector>,
@@ -1498,7 +1508,8 @@ pub struct Gate<F: Field> {
 }
 
 impl<F: Field> Gate<F> {
-    pub(crate) fn name(&self) -> &str {
+    ///Analyzer
+    pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
@@ -1540,8 +1551,10 @@ pub struct ConstraintSystem<F: Field> {
     /// tooling right now.
     pub(crate) selector_map: Vec<Column<Fixed>>,
 
-    pub(crate) gates: Vec<Gate<F>>,
-    pub(crate) advice_queries: Vec<(Column<Advice>, Rotation)>,
+    ///Analyzer
+    pub gates: Vec<Gate<F>>,
+    ///Analyzer
+    pub advice_queries: Vec<(Column<Advice>, Rotation)>,
     // Contains an integer for each advice column
     // identifying how many distinct queries it has
     // so far; should be same length as num_advice_columns.
@@ -1554,7 +1567,8 @@ pub struct ConstraintSystem<F: Field> {
 
     // Vector of lookup arguments, where each corresponds to a sequence of
     // input expressions and a sequence of table expressions involved in the lookup.
-    pub(crate) lookups: Vec<lookup::Argument<F>>,
+    ///Analyzer
+    pub lookups: Vec<lookup::Argument<F>>,
 
     // List of indexes of Fixed columns which are associated to a circuit-general Column tied to their annotation.
     pub(crate) general_column_annotations: HashMap<metadata::Column, String>,

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -8,8 +8,10 @@ pub(crate) mod verifier;
 #[derive(Clone)]
 pub struct Argument<F: Field> {
     pub(crate) name: String,
-    pub(crate) input_expressions: Vec<Expression<F>>,
-    pub(crate) table_expressions: Vec<Expression<F>>,
+    ///Analyzer
+    pub input_expressions: Vec<Expression<F>>,
+    ///Analyzer
+    pub table_expressions: Vec<Expression<F>>,
 }
 
 impl<F: Field> Debug for Argument<F> {

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -8,9 +8,9 @@ pub(crate) mod verifier;
 #[derive(Clone)]
 pub struct Argument<F: Field> {
     pub(crate) name: String,
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub input_expressions: Vec<Expression<F>>,
-    ///Analyzer
+    /// Visibility changed for analyzer
     pub table_expressions: Vec<Expression<F>>,
 }
 


### PR DESCRIPTION
Summary
This PR makes some necessary modifications to PSE halo2 to be used in the analyzer.

Changes:
The visibility of some fields, used in the analyzer, within specific structs has changed to public. The changed files are:
halo2/halo2_proofs/src/circuit.rs
halo2/halo2_proofs/src/dev.rs
halo2/halo2_proofs/src/plonk/circuit.rs
halo2/halo2_proofs/src/plonk/lookup.rs