### PR TITLE
Enable Hash and Equality on Rotation

### DIFF
--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -304,6 +304,7 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
+/// Hash and Eq added for analyzer
 #[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Rotation(pub i32);
 

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -304,7 +304,7 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Rotation(pub i32);
 
 impl Rotation {


### PR DESCRIPTION
Summary:
Added `Hash` and `Eq`  attributes to the `Rotation` struct to enable adding it to a Hash set. 
The changed file is:
halo2_proofs/src/poly.rs